### PR TITLE
Fix parsing when HOOKS is an array

### DIFF
--- a/scripts/mhwd-fb
+++ b/scripts/mhwd-fb
@@ -27,7 +27,7 @@ check_system() {
     . "${MKINITCPIOCONF}"
     local found="";
 
-    for arg in ${HOOKS}
+    for arg in ${HOOKS[@]}
     do
         if [ "${arg}" == "mhwd-fb" ]; then
             found="true"


### PR DESCRIPTION
HOOKS from /etc/mkinitcpio.conf is now an *array* and must be referred to using ${var[@}}.